### PR TITLE
chore: add financial status into orders list

### DIFF
--- a/@ecomplus/storefront-app/src/components/html/EcOrderInfo.html
+++ b/@ecomplus/storefront-app/src/components/html/EcOrderInfo.html
@@ -240,7 +240,7 @@
   </transition-group>
 
   <a
-    v-if="isNew && accountOrdersUrl"
+    v-if="accountOrdersUrl"
     :href="accountOrdersUrl"
     class="order-info__orders-link btn btn-sm btn-light"
   >

--- a/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
+++ b/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
@@ -33,7 +33,7 @@
       </span>
 
       <span
-        v-else-if="order.financial_status && order.status !== 'cancelled'"
+        v-else
         class="orders-list__financial-status"
         :class="`orders-list__financial-status--${order.financial_status.current}`"
       >

--- a/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
+++ b/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
@@ -25,7 +25,7 @@
       <span>{{ formatDate(order.created_at) }}</span>
 
       <span
-        v-if="order.status === 'cancelled'"
+        v-if="order.status === 'cancelled' || !order.financial_status"
         class="orders-list__status"
         :class="`orders-list__status--${order.status}`"
       >

--- a/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
+++ b/@ecomplus/storefront-app/src/components/html/EcOrdersList.html
@@ -25,10 +25,19 @@
       <span>{{ formatDate(order.created_at) }}</span>
 
       <span
+        v-if="order.status === 'cancelled'"
         class="orders-list__status"
         :class="`orders-list__status--${order.status}`"
       >
-        {{ i18n('_OrderStatus', order.status) }}
+        {{ i19OrderStatus(order.status) }}
+      </span>
+
+      <span
+        v-else-if="order.financial_status && order.status !== 'cancelled'"
+        class="orders-list__financial-status"
+        :class="`orders-list__financial-status--${order.financial_status.current}`"
+      >
+        {{ i19FinancialStatus(order.financial_status.current) }}
       </span>
     </a>
   </div>

--- a/@ecomplus/storefront-app/src/components/js/EcOrdersList.js
+++ b/@ecomplus/storefront-app/src/components/js/EcOrdersList.js
@@ -3,8 +3,9 @@ import ecomPassport from '@ecomplus/passport-client'
 import EcOrderInfo from './../EcOrderInfo.vue'
 
 import {
-  _OrderStatus
-} from './../../lib/i18n'
+  i19FinancialStatus,
+  i19OrderStatus
+} from '@ecomplus/i18n'
 
 export default {
   name: 'EcOrdersList',
@@ -31,22 +32,11 @@ export default {
     }
   },
 
-  computed: {
-    dictionary () {
-      return {
-        _OrderStatus,
-        ...this.mergeDictionary
-      }
-    }
-  },
-
   methods: {
     formatDate,
     formatMoney,
-
-    i18n (label, prop) {
-      return i18n(prop ? this.dictionary[label][prop] : this.dictionary[label])
-    }
+    i19FinancialStatus: prop => i18n(i19FinancialStatus)[prop],
+    i19OrderStatus: prop => i18n(i19OrderStatus)[prop]
   },
 
   created () {

--- a/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
+++ b/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
@@ -12,7 +12,7 @@
       }
 
       > span {
-        flex: 1 1 0;
+        flex: 1.4 1 0;
         text-align: right;
       }
     }
@@ -40,13 +40,15 @@
     }
   }
 
-  &__status {
+  &__status,
+  &__financial-status {
     font-weight: bold;
 
     @media (max-width: 767.98px) {
       float: right;
     }
-
+  }
+  &__status {
     &--open {
       color: var(--info);
     }
@@ -55,6 +57,27 @@
     }
     &--cancelled {
       color: var(--danger);
+    }
+  }
+
+  &__financial-status {
+
+    &--pending {
+      color: var(--warning);
+    }
+
+    &--under_analysis {
+      color: var(--info);
+    }
+
+    &--unauthorized,
+    &--in_dispute,
+    &--voided {
+      color: var(--danger);
+    }
+
+    &--paid {
+      color: var(--success);
     }
   }
 }

--- a/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
+++ b/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
@@ -48,6 +48,7 @@
       float: right;
     }
   }
+
   &__status {
     &--open {
       color: var(--info);

--- a/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
+++ b/@ecomplus/storefront-app/src/components/scss/EcOrdersList.scss
@@ -62,7 +62,6 @@
   }
 
   &__financial-status {
-
     &--pending {
       color: var(--warning);
     }


### PR DESCRIPTION
![Captura de tela de 2020-05-11 19-31-35](https://user-images.githubusercontent.com/35343551/81618596-10042d80-93be-11ea-8ca1-715bc857668c.png)

If status is cancelled i show only this main status.
If not cancelled and exist financial status i show only the current financial status (if we have financial status, the attribute current is required so...)