### PR TITLE
chore: create pages without date

### DIFF
--- a/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/blog-posts.js
+++ b/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/blog-posts.js
@@ -5,7 +5,7 @@ export default ({ baseDir, sections }) => ({
   folder: `${baseDir}content/posts`,
   extension: 'json',
   create: true,
-  slug: '{{slug}}-{{year}}-{{month}}-{{day}}',
+  slug: '{{slug}}',
   fields: [
     {
       label: 'Título',


### PR DESCRIPTION
I went to a multiple blogs and none is using date in slug url.
Creation date can be used in another place instead of slug. Multiple users ask how can cut date from url for seo, the only way to day is using github and change name of file.
Let user create his own slug, if he repeats, will be the same of product slug, no?

<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
<!--
  Paste a link to related issue if any.
-->

**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->

**Checklist**

- [ ] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [ ] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

**A picture of a cute animal**
<!--
  Your pet? Not mandatory but encouraged :)
-->
