### PR TITLE
chore: change aspect radio default video embed

### DIFF
--- a/@ecomplus/storefront-components/src/js/ProductGallery.js
+++ b/@ecomplus/storefront-components/src/js/ProductGallery.js
@@ -41,7 +41,7 @@ export default {
     video: Object,
     videoAspectRatio: {
       type: String,
-      default: '4by3'
+      default: '16by9'
     },
     canAddToCart: {
       type: Boolean,


### PR DESCRIPTION
I saw youtube and vimeo, both have 0.5625 of ratio in most. I also saw a lot of medium, stackoverflow saying that. If we have a video with ratio 0.75 will also work at 0.5625, but if we have the opposite, it wont work.
I test it both in localhost, they work perfectly just changing `videoAspectRatio`, but in production doesnt work at all in most cases.

