### PR TITLE
fix(revenue): revenue always without discount

### DIFF
--- a/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
+++ b/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
@@ -56,7 +56,7 @@ export default dataLayer => {
           } catch (e) {
           }
         }
-        const { amount } = window.storefrontApp
+        const { amount } = order || window.storefrontApp
         const actionField = {
           id: orderId,
           revenue: (

--- a/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
+++ b/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
@@ -49,6 +49,13 @@ export default dataLayer => {
 
     const emitPurchase = (orderId, orderJson) => {
       if (!isPurchaseSent) {
+        let order
+        if (orderJson) {
+          try {
+            order = JSON.parse(orderJson)
+          } catch (e) {
+          }
+        }
         const { amount } = window.storefrontApp
         const actionField = {
           id: orderId,
@@ -67,13 +74,6 @@ export default dataLayer => {
           }
         }
 
-        let order
-        if (orderJson) {
-          try {
-            order = JSON.parse(orderJson)
-          } catch (e) {
-          }
-        }
         if (order) {
           ;['payment_method_label', 'shipping_method_label'].forEach((field, i) => {
             if (order[field]) {


### PR DESCRIPTION
window.storefrontApp always have amount.discount = zero, so always send a total without discount

<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
<!--
  Paste a link to related issue if any.
-->

**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->

**Checklist**

- [ ] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [ ] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

**A picture of a cute animal**
<!--
  Your pet? Not mandatory but encouraged :)
-->
