### PR TITLE
perf(APrices): better performance when use utm

### DIFF
--- a/@ecomplus/storefront-components/src/html/APrices.html
+++ b/@ecomplus/storefront-components/src/html/APrices.html
@@ -82,5 +82,13 @@
         </span>
       </template>
     </div>
+    <span
+      class="product__discount"
+      v-if="discountTagValue > 0 && canShowDiscountTag"
+      key="discountTagValue"
+    >
+      {{ i19discountOf }}
+      <strong>{{ discountTagValue }}%</strong>
+    </span>
   </transition-group>
 </div>

--- a/@ecomplus/storefront-components/src/html/TheProduct.html
+++ b/@ecomplus/storefront-components/src/html/TheProduct.html
@@ -96,23 +96,11 @@
               <p class="product__prices">
                 <a-prices
                   :product="ghostProductForPrices"
+                  :canShowDiscountTag="true"
                   :is-literal="true"
                   :is-big="true"
                   @fix-price="price => fixedPrice = price"
                 />
-
-                <slot
-                  name="discount-tag"
-                  v-bind="{ discount }"
-                >
-                  <span
-                    v-if="discount > 0"
-                    class="product__discount"
-                  >
-                    {{ i19discountOf }}
-                    <strong>{{ discount }}%</strong>
-                  </span>
-                </slot>
               </p>
             </slot>
 

--- a/@ecomplus/storefront-components/src/js/APrices.js
+++ b/@ecomplus/storefront-components/src/js/APrices.js
@@ -1,5 +1,6 @@
 import {
   i19asOf,
+  i19discountOf,
   i19from,
   i19interestFree,
   i19of,
@@ -50,6 +51,10 @@ export default {
     canShowPriceOptions: {
       type: Boolean,
       default: true
+    },
+    canShowDiscountTag: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -75,6 +80,7 @@ export default {
 
   computed: {
     i19asOf: () => i18n(i19asOf),
+    i19discountOf: () => i18n(i19discountOf),
     i19from: () => i18n(i19from),
     i19interestFree: () => i18n(i19interestFree),
     i19of: () => i18n(i19of),
@@ -120,6 +126,14 @@ export default {
 
     priceWithDiscount () {
       return this.canShowPriceOptions && getPriceWithDiscount(this.price, this.discount)
+    },
+
+    discountTagValue () {
+      const { product } = this
+      const priceValue = this.price || getPrice(product)
+      return checkOnPromotion(product) || this.extraDiscount.value > 0
+        ? Math.round(((product.base_price - priceValue) * 100) / product.base_price)
+        : 0
     },
 
     installmentValue () {

--- a/@ecomplus/storefront-components/src/js/TheProduct.js
+++ b/@ecomplus/storefront-components/src/js/TheProduct.js
@@ -3,7 +3,6 @@ import {
   i19buy,
   i19close,
   i19days,
-  i19discountOf,
   // i19endsIn,
   i19freeShippingFrom,
   i19loadProductErrorMsg,
@@ -168,7 +167,6 @@ export default {
     i19addToFavorites: () => i18n(i19addToFavorites),
     i19close: () => i18n(i19close),
     i19days: () => i18n(i19days),
-    i19discountOf: () => i18n(i19discountOf),
     i19endsIn: () => i18n({
       pt_br: 'Acaba em',
       en_us: 'Ends in'
@@ -236,14 +234,6 @@ export default {
 
     strBuy () {
       return this.buyText || i18n(i19buy)
-    },
-
-    discount () {
-      const { body } = this
-      const priceValue = this.fixedPrice || getPrice(body)
-      return checkOnPromotion(body)
-        ? Math.round(((body.base_price - priceValue) * 100) / body.base_price)
-        : 0
     },
 
     isOnSale () {


### PR DESCRIPTION
When use utm, discount tag wasnt updated. So, instead of get apply discount on TheProduct component, so put discount tag on APrice and by default doesnt show this tag, only when canShowDiscountTag is set to true at the specified component, just like TheProduct