### PR TITLE
fix(quantity-selector/scss): repair quantity selector broken styles

### DIFF
--- a/@ecomplus/storefront-components/src/scss/QuantitySelector.scss
+++ b/@ecomplus/storefront-components/src/scss/QuantitySelector.scss
@@ -1,6 +1,10 @@
 .quantity-selector {
   &__btn-container {
     min-width: 7rem;
+
+    button {
+      max-width: 28px;
+    }
   }
 
   &__item {

--- a/@ecomplus/storefront-template/template/scss/themes/ecom-beauty/_product.scss
+++ b/@ecomplus/storefront-template/template/scss/themes/ecom-beauty/_product.scss
@@ -104,7 +104,7 @@ main {
         }
       }
 
-      .quantity-selector {
+      .quantity-selector {        
         &__btn-container {
           height: 44px;
           width: 135px;
@@ -112,10 +112,24 @@ main {
           justify-content: center;
           border: 1px solid #C8C8C8;
           border-radius: 4px;
+
+          button {
+            padding: var(--spacer-2) var(--spacer-1);
+          }
+
+          @media (max-width: 575.98px) {
+            display: none;
+          }
         }
 
         &__input {
           border: none;
+        }
+
+        &__label {
+          @media (max-width: 575.98px) {
+            width: 100%;
+          }
         }
       }
 
@@ -137,6 +151,14 @@ main {
 
       .i-chevron-down::before {
         content: '-';
+      }
+    }
+
+    .quantity-selector__buy {
+      button {
+        @media (max-width: 575.98px) {
+          width: 100%;
+        }
       }
     }
 


### PR DESCRIPTION
**Summary**
Fix broken styles on quantity selector mobile view caused after PR https://github.com/ecomplus/storefront/pull/746 changes.

**Screenshots**
![image](https://user-images.githubusercontent.com/7574584/180503106-c9feef19-10f7-4ca6-a685-b1d772e042c3.png)


**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;
