### PR TITLE
feat(storefront-template/header): Alphabetical order submenu

### DIFF
--- a/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/layout/header.js
+++ b/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/layout/header.js
@@ -119,6 +119,16 @@ export default ({ baseDir, state }) => ({
       label: 'Mostrar input de busca',
       name: 'search_input',
       widget: 'boolean'
+    },
+    {
+      label: 'Submenu em ordem alfabética',
+      name: 'alphabetical_order_submenu',
+      widget: 'boolean'
+    },
+    {
+      label: 'Submenu em tela cheia',
+      name: 'full_width_submenu',
+      widget: 'boolean'
     }
   ]
 })

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -46,7 +46,7 @@ if (header.categories_list) {
   isCategoriesNavFull = header.categories_list.full_width
 }
 const hasMegamenu = header.desktop_megamenu
-const alphabeticalOrderSubmenu = header.alphabetical_order_submenu
+const isAlphabeticalOrderSubmenu = header.alphabetical_order_submenu
 const fullWidthSubmenu = header.full_width_submenu
 %>
 

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -291,7 +291,7 @@ const fullWidthSubmenu = header.full_width_submenu
                         })
                       }
                     %>
-                    <nav class="header__submenu <%= fullWidthSubmenu ? 'header__submenu--full' : '' %>" id="<%= `s-${slug.replace(/\//g, '_')}` %>">
+                    <nav class="header__submenu<%= fullWidthSubmenu ? ' header__submenu--full' : '' %>" id="<%= `s-${slug.replace(/\//g, '_')}` %>">
                       <% subcategories.forEach(subcategory => { %>
                         <div>               
                           <a id="sd-<%= subcategory._id %>" href="/<%= subcategory.slug %>"><%= subcategory.name %></a>

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -285,7 +285,7 @@ const fullWidthSubmenu = header.full_width_submenu
                   <% const subcategories = _.categories.filter(({ parent }) => parent && parent.slug === slug) %>
                   <% if (subcategories.length) { %>
                     <%
-                      if (alphabeticalOrderSubmenu) {
+                      if (isAlphabeticalOrderSubmenu) {
                         subcategories.sort((a, b)=> {
                           return b.name > a.name ? -1 : 1
                         })

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -46,6 +46,8 @@ if (header.categories_list) {
   isCategoriesNavFull = header.categories_list.full_width
 }
 const hasMegamenu = header.desktop_megamenu
+const alphabeticalOrderSubmenu = header.alphabetical_order_submenu
+const fullWidthSubmenu = header.full_width_submenu
 %>
 
 <div id="overlay" class="fade"></div>
@@ -282,11 +284,25 @@ const hasMegamenu = header.desktop_megamenu
                 <%  if (slug && hasMegamenu) { %>
                   <% const subcategories = _.categories.filter(({ parent }) => parent && parent.slug === slug) %>
                   <% if (subcategories.length) { %>
-                    <nav class="header__submenu" id="<%= `s-${slug.replace(/\//g, '_')}` %>">
+                    <%
+                      if (alphabeticalOrderSubmenu) {
+                        subcategories.sort((a, b)=> {
+                          return b.name > a.name ? -1 : 1
+                        })
+                      }
+                    %>
+                    <nav class="header__submenu <%= fullWidthSubmenu ? 'header__submenu--full' : '' %>" id="<%= `s-${slug.replace(/\//g, '_')}` %>">
                       <% subcategories.forEach(subcategory => { %>
                         <div>               
                           <a id="sd-<%= subcategory._id %>" href="/<%= subcategory.slug %>"><%= subcategory.name %></a>
                           <% const thirdCategories = _.categories.filter(({ parent }) => parent && parent.slug === subcategory.slug) %>
+                          <%
+                            if (alphabeticalOrderSubmenu) {
+                              thirdCategories.sort((a, b)=> {
+                                return b.name > a.name ? -1 : 1
+                              })
+                            }
+                          %>
                           <% thirdCategories.forEach(thirdCategory => { %>
                             <a id="td-<%= thirdCategory._id %>" class="header__submenu-subcategory" href="/<%= thirdCategory.slug %>">
                               <%= thirdCategory.name %>

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -297,7 +297,7 @@ const fullWidthSubmenu = header.full_width_submenu
                           <a id="sd-<%= subcategory._id %>" href="/<%= subcategory.slug %>"><%= subcategory.name %></a>
                           <% const thirdCategories = _.categories.filter(({ parent }) => parent && parent.slug === subcategory.slug) %>
                           <%
-                            if (alphabeticalOrderSubmenu) {
+                            if (isAlphabeticalOrderSubmenu) {
                               thirdCategories.sort((a, b)=> {
                                 return b.name > a.name ? -1 : 1
                               })

--- a/@ecomplus/storefront-template/template/scss/components/_header.scss
+++ b/@ecomplus/storefront-template/template/scss/components/_header.scss
@@ -111,10 +111,6 @@
     max-width: 500px;
     text-align: left;
     overflow: auto;
-
-    &::after {
-      display: none;
-    }
   
     &::-webkit-scrollbar {
       width: 4px;
@@ -143,6 +139,10 @@
 
       a {
         display: block;
+      }
+      
+      &::after {
+        display: none;
       }
     }
 

--- a/@ecomplus/storefront-template/template/scss/components/_header.scss
+++ b/@ecomplus/storefront-template/template/scss/components/_header.scss
@@ -110,6 +110,41 @@
     min-width: 300px;
     max-width: 500px;
     text-align: left;
+    overflow: auto;
+
+    &::after {
+      display: none;
+    }
+  
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+  
+    &::-webkit-scrollbar-thumb {
+      background: var(--secondary);
+    }
+  
+    &::-webkit-scrollbar-track {
+      background: var(--primary-yiq);
+    }
+
+    &--full {
+      width: 98%;
+      max-width: 1200px;
+      max-height: 600px;
+      left: 50%;
+      transform: translateX(-50%);
+      scrollbar-width: thin;
+      scrollbar-color: var(--secondary) var(--primary-yiq);
+
+      .header__submenu-subcategory {
+        width: 180px;
+      }
+
+      a {
+        display: block;
+      }
+    }
 
     &::after {
       content: '';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
https://community.e-com.plus/t/menu-aberto-com-todas-as-categorias/4172

**Summary**
Add option on cms to order subcategories in alphabetical order.
Add option cms option to set full width on megamenu.

**Screenshots**
![image](https://user-images.githubusercontent.com/7574584/185484376-144707f0-ae3e-4849-a73d-5de250a2d951.png)
![image](https://user-images.githubusercontent.com/7574584/185485719-907d5736-5bc3-4f0c-8ace-5b26ee0e953c.png)

**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

**A picture of a cute animal**
![image](https://user-images.githubusercontent.com/7574584/185486322-7bb85b3d-e33f-47be-8c16-ef4348ce1424.png)

