### PR TITLE
chore(collection-shelf): autoplay into config and pass to carousel

### DIFF
--- a/@ecomplus/storefront-template/template/js/netlify-cms/base-config/sections.js
+++ b/@ecomplus/storefront-template/template/js/netlify-cms/base-config/sections.js
@@ -300,6 +300,15 @@ export default ({ state }) => [
         widget: 'number',
         min: 1,
         default: 1
+      },
+      {
+        label: 'Carousel autoplay',
+        required: false,
+        name: 'autoplay',
+        hint: 'Exibição de cada página em milisegundos, 0 desativa o autoplay',
+        min: 0,
+        step: 1000,
+        widget: 'number'
       }
     ]
   },

--- a/@ecomplus/storefront-template/template/pages/@/sections/collection-shelf.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/sections/collection-shelf.ejs
@@ -1,5 +1,5 @@
 <%
-let { title, link, shuffle, headless } = opt
+let { title, link, shuffle, headless, autoplay } = opt
 let items, collection
 if (opt.sort || opt.collection_id) {
   let search, productIds
@@ -68,6 +68,6 @@ if (opt.sort || opt.collection_id) {
 
 <div class="collection-shelf my-lg-5">
   <%- await include('@/sections/inc/products-carousel', {
-    _, opt: { items, collection, title, link, shuffle, headless }
+    _, opt: { items, collection, title, link, shuffle, headless, autoplay }
   }) %>
 </div>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
<!--
  Paste a link to related issue if any.
-->

**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->

**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

Basicamente estava previsto no carousel, mas não tinha em nenhum lugar a configuração, como já existe no carousel de marcas e no slider, porque não.
