### PR TITLE
chore(watch-app-routes): use sha256 for customer id at external_id

### DIFF
--- a/@ecomplus/widget-fb-pixel/src/lib/watch-app-routes.js
+++ b/@ecomplus/widget-fb-pixel/src/lib/watch-app-routes.js
@@ -44,7 +44,7 @@ export default (fbq, options) => {
       }
     }
 
-    const emitPurchase = async (orderId, orderJson) => {
+    const emitPurchase = (orderId, orderJson) => {
       if (!isPurchaseSent && window.localStorage.getItem('fbq.orderIdSent') !== orderId) {
         let order
         if (orderJson) {

--- a/@ecomplus/widget-fb-pixel/src/lib/watch-app-routes.js
+++ b/@ecomplus/widget-fb-pixel/src/lib/watch-app-routes.js
@@ -60,24 +60,16 @@ export default (fbq, options) => {
         } else {
           eventID = orderId
         }
-        let buyerSha256
+        let externalId
         if (Array.isArray(order.buyers) && order.buyers.length) {
-          const buyerId = order.buyers[0]._id
-          async function sha256Text(message) {
-            const msgUint8 = new TextEncoder().encode(message);                         
-            const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);         
-            const hashArray = Array.from(new Uint8Array(hashBuffer));
-            const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-            return hashHex;
-          }
-          buyerSha256 = await sha256Text(buyerId)
+          externalId = order.buyers[0]._id
         }
         if (options.disablePurchase !== true) {
           fbq('Purchase', {
             ...getPurchaseData(order),
             order_id: orderId,
             eventID,
-            external_id: buyerSha256
+            external_id: externalId
           })
         }
         ecomPassport.requestApi(`/orders/${orderId}/metafields.json`, 'POST', {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
<!--
  Paste a link to related issue if any.
-->

**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->

**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

Por conta da atualização do app da api do facebook com envio o id do cliente, o pixel passa a ter essa informação como obrigatória também e precisando enviar a mesma informação, no caso, com encriptação sha256
