### PR TITLE
chore(header): centralized logo option

### DIFF
--- a/@ecomplus/storefront-template/content/header.json
+++ b/@ecomplus/storefront-template/content/header.json
@@ -22,6 +22,7 @@
     "random": 6,
     "full_width": false
   },
+  "centralized_logo": false,
   "desktop_megamenu": false,
   "search_input": true,
   "alphabetical_order_submenu": false,

--- a/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/layout/header.js
+++ b/@ecomplus/storefront-template/template/js/netlify-cms/base-config/collections/layout/header.js
@@ -111,6 +111,12 @@ export default ({ baseDir, state }) => ({
       ]
     },
     {
+      label: 'Logotipo centralizado',
+      hint: 'Logotipo centralizado, se estiver ativo exibir categorias em largura total',
+      name: 'centralized_logo',
+      widget: 'boolean'
+    },
+    {
       label: 'Megamenu no desktop',
       name: 'desktop_megamenu',
       widget: 'boolean'

--- a/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/layout/header.ejs
@@ -48,6 +48,7 @@ if (header.categories_list) {
 const hasMegamenu = header.desktop_megamenu
 const isAlphabeticalOrderSubmenu = header.alphabetical_order_submenu
 const fullWidthSubmenu = header.full_width_submenu
+const isCentralizedLogo = header.centralized_logo
 %>
 
 <div id="overlay" class="fade"></div>
@@ -121,7 +122,7 @@ const fullWidthSubmenu = header.full_width_submenu
 
 <header class="header" id="header">
   <div class="header__container container-fluid">
-    <div class="header__row row">
+    <div class="header__row row<%= isCentralizedLogo ? ' header__row--centralized-logo' : '' %><%= isCentralizedLogo && isCategoriesNavFull ? ' full_width' : '' %>">
       <div class="col-auto p-0">
         <button
           class="btn header__toggler<%= hasMegamenu ? ' d-lg-none' : '' %>"

--- a/@ecomplus/storefront-template/template/scss/components/_header.scss
+++ b/@ecomplus/storefront-template/template/scss/components/_header.scss
@@ -28,6 +28,43 @@
 
     @media (min-width: 768px) {
       min-height: 60px;
+      &--centralized-logo {
+        > .col-auto.p-0 {
+          order: -2;
+          flex-basis: 3%;
+          max-width: 3%;
+        }
+        .col.col-lg-auto.pl-1.pl-md-2.pl-lg-3 {
+          flex-basis: 33.33%;
+          max-width: 33.33%;
+          display: flex;
+          justify-content: center;
+        }
+        .order-lg-last.col-auto.p-0 {
+          display: flex;
+          flex-basis: 8%;
+          max-width: 8%;
+          justify-content: flex-end;
+          order: 13;
+        }
+        .d-none.d-lg-block.col {
+          display: flex !important;
+          flex: 0 0 25.33%;
+        }
+        #search-bar {
+          flex-basis: 30.33%;
+          max-width: 30.33%;
+          order: -1;
+          display: flex !important;
+          justify-content: flex-start;
+        }
+      }
+      &.full_width {
+        .order-lg-last.col-auto.p-0 {
+          flex-basis: 33.33% !important;
+          max-width: 33.33% !important;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->
Two types:
- Only centralized logo active:
<img width="956" alt="header-centered" src="https://user-images.githubusercontent.com/35343551/229590792-fbf3ae91-14df-457d-9e84-9d9058d3e2c7.png">

- Centralized logo and full_width active:

![Screenshot 2023-04-03 at 15-01-00 My Shop](https://user-images.githubusercontent.com/35343551/229590931-baa74520-dabe-4e3c-99d9-e04d9edf7473.png)


**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;
