### PR TITLE
feat(minicart): option to show shipping calculator

### DIFF
--- a/@ecomplus/storefront-components/src/html/CartQuickview.html
+++ b/@ecomplus/storefront-components/src/html/CartQuickview.html
@@ -77,11 +77,11 @@
           > 
             <hr>
             <shipping-calculator
-                class="minicart__shipping-calculator"
-                :can-select-services="true"
-                :shipped-items="cart.items"
-                @select-service="selectShippingService"
-              />
+              class="minicart__shipping-calculator"
+              :can-select-services="true"
+              :shipped-items="cart.items"
+              @select-service="selectShippingService"
+            />
           </div>
         </transition-group>
       </article>

--- a/@ecomplus/storefront-components/src/html/CartQuickview.html
+++ b/@ecomplus/storefront-components/src/html/CartQuickview.html
@@ -69,6 +69,20 @@
               </a>
             </slot>
           </div>
+
+          <div
+            class="minicart__shipping"
+            v-if="cart.items.length && hasShippingCalculator"
+            key="shipping"
+          > 
+            <hr>
+            <shipping-calculator
+                class="minicart__shipping-calculator"
+                :can-select-services="true"
+                :shipped-items="cart.items"
+                @select-service="selectShippingService"
+              />
+          </div>
         </transition-group>
       </article>
 
@@ -81,7 +95,7 @@
             <span>{{ i19subtotal }}</span>
             <div class="minicart__subtotal">
               <a-prices
-                :product="{ price: cart.subtotal }"
+                :product="{ price: total || cart.subtotal }"
                 :is-literal="true"
               />
             </div>

--- a/@ecomplus/storefront-components/src/js/CartQuickview.js
+++ b/@ecomplus/storefront-components/src/js/CartQuickview.js
@@ -36,10 +36,7 @@ export default {
       type: Boolean,
       default: true
     },
-    hasShippingCalculator: {
-      typy: Boolean,
-      default: false
-    },
+    hasShippingCalculator: Boolean,
     checkoutUrl: {
       type: String,
       default: '/app/#/checkout'

--- a/@ecomplus/storefront-components/src/js/CartQuickview.js
+++ b/@ecomplus/storefront-components/src/js/CartQuickview.js
@@ -18,6 +18,7 @@ import ALink from '../ALink.vue'
 import ABackdrop from '../ABackdrop.vue'
 import APrices from '../APrices.vue'
 import CartItem from '../CartItem.vue'
+import ShippingCalculator from '../ShippingCalculator.vue'
 
 export default {
   name: 'CartQuickview',
@@ -26,13 +27,18 @@ export default {
     ALink,
     ABackdrop,
     APrices,
-    CartItem
+    CartItem,
+    ShippingCalculator
   },
 
   props: {
     isVisible: {
       type: Boolean,
       default: true
+    },
+    hasShippingCalculator: {
+      typy: Boolean,
+      default: false
     },
     checkoutUrl: {
       type: String,
@@ -54,6 +60,12 @@ export default {
     }
   },
 
+  data () {
+    return {
+      selectedShippingPrice: 0
+    }
+  },
+
   computed: {
     i19checkout: () => i18n(i19checkout),
     i19close: () => i18n(i19close),
@@ -65,6 +77,10 @@ export default {
 
     cart () {
       return this.ecomCart.data
+    },
+
+    total () {
+      return this.cart.subtotal + this.selectedShippingPrice
     }
   },
 
@@ -76,7 +92,13 @@ export default {
         'update:is-visible',
         typeof isVisible === 'boolean' ? isVisible : !this.isVisible
       )
-    }
+    },
+
+    selectShippingService (service) {
+      this.selectedShippingPrice = service.shipping_line
+      ? service.shipping_line.total_price
+      : 0
+    },
   },
 
   created () {

--- a/@ecomplus/storefront-components/src/js/CartQuickview.js
+++ b/@ecomplus/storefront-components/src/js/CartQuickview.js
@@ -93,8 +93,8 @@ export default {
 
     selectShippingService (service) {
       this.selectedShippingPrice = service.shipping_line
-      ? service.shipping_line.total_price
-      : 0
+        ? service.shipping_line.total_price
+        : 0
     },
   },
 

--- a/@ecomplus/storefront-template/content/widgets/minicart.json
+++ b/@ecomplus/storefront-template/content/widgets/minicart.json
@@ -2,5 +2,7 @@
   "pkg": "@ecomplus/widget-minicart",
   "active": true,
   "desktopOnly": false,
-  "options": {}
+  "options": {
+    "strHasShippingCalculator": "_"
+  }
 }

--- a/@ecomplus/widget-minicart/cms.config.js
+++ b/@ecomplus/widget-minicart/cms.config.js
@@ -20,6 +20,33 @@ export default () => ({
       name: 'desktopOnly',
       hint: 'Desativa o widget em dispositivos móveis',
       widget: 'boolean'
+    },
+    {
+      label: 'Opções',
+      name: 'options',
+      widget: 'object',
+      hint: 'Personalizações do widget',
+      fields: [
+        {
+          label: 'Cálculo de frete',
+          name: 'strHasShippingCalculator',
+          widget: 'select',
+          options: [
+            {
+              label: 'Padrão do tema',
+              value: '_'
+            },
+            {
+              label: 'Sem cálculo de frete (carrinho lateral)',
+              value: ' '
+            },
+            {
+              label: 'Cálculo de frete (carrinho lateral)',
+              value: 'true'
+            }
+          ]
+        }
+      ]
     }
   ]
 })

--- a/@ecomplus/widget-minicart/cms.config.js
+++ b/@ecomplus/widget-minicart/cms.config.js
@@ -37,11 +37,11 @@ export default () => ({
               value: '_'
             },
             {
-              label: 'Sem cálculo de frete (carrinho lateral)',
+              label: 'Sem cálculo de frete no minicart',
               value: ' '
             },
             {
-              label: 'Cálculo de frete (carrinho lateral)',
+              label: 'Cálculo de frete no minicart',
               value: 'true'
             }
           ]

--- a/@ecomplus/widget-minicart/src/index.js
+++ b/@ecomplus/widget-minicart/src/index.js
@@ -10,7 +10,6 @@ import CartQuickview from '#components/CartQuickview.vue'
 export default (options = {}, elId = 'cart-quickview', buttonId = 'cart-button') => {
   const $cartQuickview = document.getElementById(elId)
   const $cartButton = document.getElementById(buttonId)
-  let getScopedSlots, themeConfig
   if ($cartQuickview && $cartButton) {
     const getScopedSlots = window.storefront && window.storefront.getScopedSlots
     const themeConfig = storefront.theme && storefront.theme.minicart

--- a/@ecomplus/widget-minicart/src/index.js
+++ b/@ecomplus/widget-minicart/src/index.js
@@ -12,8 +12,8 @@ export default (options = {}, elId = 'cart-quickview', buttonId = 'cart-button')
   const $cartButton = document.getElementById(buttonId)
   let getScopedSlots, themeConfig
   if ($cartQuickview && $cartButton) {
-    getScopedSlots = window.storefront && window.storefront.getScopedSlots
-    themeConfig = storefront.theme && storefront.theme.product
+    const getScopedSlots = window.storefront && window.storefront.getScopedSlots
+    const themeConfig = storefront.theme && storefront.theme.minicart
 
     const {
       strHasShippingCalculator

--- a/@ecomplus/widget-minicart/src/index.js
+++ b/@ecomplus/widget-minicart/src/index.js
@@ -10,8 +10,20 @@ import CartQuickview from '#components/CartQuickview.vue'
 export default (options = {}, elId = 'cart-quickview', buttonId = 'cart-button') => {
   const $cartQuickview = document.getElementById(elId)
   const $cartButton = document.getElementById(buttonId)
+  let getScopedSlots, themeConfig
   if ($cartQuickview && $cartButton) {
-    const getScopedSlots = window.storefront && window.storefront.getScopedSlots
+    getScopedSlots = window.storefront && window.storefront.getScopedSlots
+    themeConfig = storefront.theme && storefront.theme.product
+
+    const {
+      strHasShippingCalculator
+    } = options
+
+    const strOptionToBool = (strOption, prop) => {
+      return strOption === '_'
+        ? Boolean(themeConfig && themeConfig[prop])
+        : strOption ? Boolean(strOption.trim()) : false
+    }
 
     new Vue({
       data: {
@@ -32,7 +44,8 @@ export default (options = {}, elId = 'cart-quickview', buttonId = 'cart-button')
           },
           props: {
             ...options.props,
-            isVisible: vm.isVisible
+            isVisible: vm.isVisible,
+            hasShippingCalculator: strOptionToBool(strHasShippingCalculator, 'hasShippingCalculator')
           },
           on: {
             'update:is-visible' (isVisible) {


### PR DESCRIPTION
**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->
Some clients asked this implementation option. So, this pr allow client to choose if they want shipping calculator in minicart or not.

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->
<img width="960" alt="Captura de tela 2023-06-05 135431" src="https://github.com/ecomplus/storefront/assets/35343551/41624eb3-d80e-4edd-8966-92b29c025ad9">
<img width="960" alt="Captura de tela 2023-06-05 135553" src="https://github.com/ecomplus/storefront/assets/35343551/71211a3d-cdc6-4551-a85d-8ccf8d9562e5">


**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;
