### PR TITLE
chore(product-block): modify json ld for selected variation

### DIFF
--- a/@ecomplus/storefront-template/template/pages/@/sections/product-block.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/sections/product-block.ejs
@@ -253,8 +253,8 @@ if (_.state.gtin && _.state.gtin[0]) {
         const jsonLd = JSON.parse($jsonLd.innerText);
         jsonLd.sku = selectedVariation.sku;
         jsonLd.offers.price = selectedVariation.price;
-        jsonLd.name = selectedVariation.name.replace('"', '') || jsonLd.name
-        jsonLd.offers.url = `${jsonLd.offers.url}?variation_id=${variationId}`
+        jsonLd.name = selectedVariation.name.replace('"', '') || jsonLd.name;
+        jsonLd.offers.url = `${jsonLd.offers.url}?variation_id=${variationId}`;
         document.querySelector('#product-block-jsonld').innerText = JSON.stringify(jsonLd);
       }
     }

--- a/@ecomplus/storefront-template/template/pages/@/sections/product-block.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/sections/product-block.ejs
@@ -253,6 +253,8 @@ if (_.state.gtin && _.state.gtin[0]) {
         const jsonLd = JSON.parse($jsonLd.innerText);
         jsonLd.sku = selectedVariation.sku;
         jsonLd.offers.price = selectedVariation.price;
+        jsonLd.name = selectedVariation.name.replace('"', '') || jsonLd.name
+        jsonLd.offers.url = `${jsonLd.offers.url}?variation_id=${variationId}`
         document.querySelector('#product-block-jsonld').innerText = JSON.stringify(jsonLd);
       }
     }


### PR DESCRIPTION
**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

When google shopping search for our structured data, we need to show information from that product only. So if title is X in xml, we need to show that title. If we set link with variation_id param, at json ld we need to set the same.

**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;
