### PR TITLE
chore(the-product): chrome and safari doesnt support a clone from urlSearchParam

### DIFF
--- a/@ecomplus/storefront-components/src/js/TheProduct.js
+++ b/@ecomplus/storefront-components/src/js/TheProduct.js
@@ -427,7 +427,7 @@ export default {
         searchParams.set('variation_id', variationId)
         window.history.pushState({
           pathname,
-          param: searchParams.toString()
+          params: searchParams.toString()
         }, '', `${pathname}?${searchParams.toString()}`)
         this.showVariationPicture(this.selectedVariation)
       }

--- a/@ecomplus/storefront-components/src/js/TheProduct.js
+++ b/@ecomplus/storefront-components/src/js/TheProduct.js
@@ -427,7 +427,7 @@ export default {
         searchParams.set('variation_id', variationId)
         window.history.pushState({
           pathname,
-          searchParams
+          param: searchParams.toString()
         }, '', `${pathname}?${searchParams.toString()}`)
         this.showVariationPicture(this.selectedVariation)
       }


### PR DESCRIPTION
**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

When attempting to use `history.pushState` with a cloned `urlSearchParams` object within that state, it functions correctly in Firefox. However, in Safari and Chrome, an error is displayed indicating that cloning `urlSearchParams` is not feasible.