### PR TITLE
chore(shipping-calculator): avoid skip shipping result if has only one

### DIFF
--- a/@ecomplus/storefront-components/src/js/ShippingCalculator.js
+++ b/@ecomplus/storefront-components/src/js/ShippingCalculator.js
@@ -154,7 +154,7 @@ export default {
           if (!validated || error) {
             return
           }
-          if (this.skipAppIds && this.skipAppIds.includes(appResult.app_id)) {
+          if (this.skipAppIds && this.skipAppIds.includes(appResult.app_id) && (shippingResult.length !== 1)) {
             return
           }
           response.shipping_services.forEach(service => {

--- a/@ecomplus/storefront-components/src/js/ShippingCalculator.js
+++ b/@ecomplus/storefront-components/src/js/ShippingCalculator.js
@@ -154,7 +154,11 @@ export default {
           if (!validated || error) {
             return
           }
-          if (this.skipAppIds && this.skipAppIds.includes(appResult.app_id) && (shippingResult.length !== 1)) {
+          if (
+            this.skipAppIds &&
+            this.skipAppIds.includes(appResult.app_id) &&
+            shippingResult.filter(({ app_id: appId }) => !this.skipAppIds.includes(appId)).length
+          ) {
             return
           }
           response.shipping_services.forEach(service => {


### PR DESCRIPTION
Skip only, if store has more then one option. Avoid stopping checkout and loop shipping request

<!--
  Thanks for submitting a pull request!
  Please make sure you've read and understood our contributing guidelines.
-->

**Related issue**
<!--
  Paste a link to related issue if any.
-->

**Summary**
<!--
  Explain what it changes and the motivations for making this change.
  You can skip it if already explained on related issue body/conversation.
-->

**Screenshots**
<!--
  Screenshots/videos if the PR changes UI.
-->

**Checklist**

- [x] I've read and understood [contributing guidelines](https://github.com/ecomplus/storefront/blob/master/CONTRIBUTING.md);
- [x] If changing UI, I've tested on most common viewports, desktop and mobile devices;

<!--
  You may also add here custom commands you ran and their outputs for tests.
-->

