### PR TITLE
fix(widget-tag-manager): send price fields as float to GTM dataLayer

### DIFF
--- a/@ecomplus/widget-tag-manager/src/lib/common.js
+++ b/@ecomplus/widget-tag-manager/src/lib/common.js
@@ -11,7 +11,7 @@ export const getProductData = item => {
   const productData = {
     name,
     id: item.sku,
-    price: getPrice(item).toFixed(2)
+    price: parseFloat(getPrice(item).toFixed(2))
   }
   if (variants && variants.length) {
     productData.variant = variants.join(' / ')

--- a/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
+++ b/@ecomplus/widget-tag-manager/src/lib/watch-app-routes.js
@@ -71,18 +71,18 @@ export default dataLayer => {
           const { amount } = order || window.storefrontApp
           const actionField = {
             id: orderId,
-            revenue: (
+            revenue: parseFloat((
               (amount && amount.total) ||
               (ecomCart.data && ecomCart.data.subtotal) ||
               0
-            ).toFixed(2)
+            ).toFixed(2))
           }
           if (amount) {
             if (amount.freight !== undefined) {
-              actionField.shipping = amount.freight.toFixed(2)
+              actionField.shipping = parseFloat(amount.freight.toFixed(2))
             }
             if (amount.tax !== undefined) {
-              actionField.tax = amount.tax.toFixed(2)
+              actionField.tax = parseFloat(amount.tax.toFixed(2))
             }
           }
 


### PR DESCRIPTION
Google Ads is rejecting string values in `price` field, causing "Item price formatted incorrectly or missing" errors. Wrap .toFixed(2) calls with parseFloat() to ensure numeric types.

https://community.e-com.plus/t/evento-do-google-ads-com-problema/7433/2
support.google.com/google-ads/answer/14943675