### PR TITLE
fix(checkout): skip AccountForm when passport session is invalid

### DIFF
--- a/@ecomplus/storefront-app/src/components/js/EcCheckout.js
+++ b/@ecomplus/storefront-app/src/components/js/EcCheckout.js
@@ -18,6 +18,7 @@ import {
 } from '@ecomplus/utils'
 
 import ecomCart from '@ecomplus/shopping-cart'
+import ecomPassport from '@ecomplus/passport-client'
 import scrollToElement from '#components/js/helpers/scroll-to-element'
 import baseModulesRequestData from '../../lib/base-modules-request-data'
 import DiscountApplier from '#components/DiscountApplier.vue'
@@ -148,7 +149,7 @@ export default {
       checkoutAppId: 1,
       toCheckoutStep: this.checkoutStep,
       customerEmail: this.customer.main_email,
-      isUserIdentified: Boolean(this.customer.main_email),
+      isUserIdentified: Boolean(this.customer.main_email) && ecomPassport.checkLogin(),
       editAccount: false,
       editShippingService: !this.shippingService,
       localZipCode: this.shippingZipCode,
@@ -389,6 +390,9 @@ export default {
     'customer.main_email' (email) {
       if (email) {
         this.customerEmail = email
+      } else {
+        this.customerEmail = ''
+        this.isUserIdentified = false
       }
     },
 


### PR DESCRIPTION
Problema

Ao clicar em "Finalizar Compra", usuários com interações anteriores no checkout na mesma sessão SPA eram enviados diretamente para "Complete seu cadastro" (AccountForm) em vez de ver o campo de email (LoginBlock). Recarregar a página resolvia.

Causa raiz

EcCheckout inicializa isUserIdentified = Boolean(this.customer.main_email) — sincronamente, a partir do Vuex. O Vuex retém o main_email em memória durante toda a sessão SPA sempre que o usuário digita no campo de email do checkout. Na próxima visita ao checkout (mesma aba, sem reload), o componente já nasce com isUserIdentified = true, mas sem perfil completo (hasBuyerInfo = false), caindo direto no AccountForm sem passar pelo LoginBlock.

Evidência

Capturado ao vivo com o bug ativo: Vuex tinha main_email preenchido, mas _id, name e phones vazios. ecomPassport.checkLogin() retornava false e getCustomer() retornava {} — nenhuma sessão válida no passport-client. O estado do Vuex e do passport-client estavam completamente desincronizados.

Adicionalmente: ao resetar o Vuex via console, a tela não mudou — isUserIdentified é estado local do componente e o watcher de customer.main_email só age quando o email é truthy, nunca revertendo para false.

Correção

Vincular isUserIdentified à existência de sessão válida no passport-client na inicialização, e corrigir o watcher para também reagir quando o email é removido.