### PR TITLE
feat(storefront-template): add review-carousel section

### DIFF
--- a/@ecomplus/storefront-template/template/js/netlify-cms/base-config/sections.js
+++ b/@ecomplus/storefront-template/template/js/netlify-cms/base-config/sections.js
@@ -461,6 +461,66 @@ export default ({ state }) => [
     ]
   },
   {
+    label: 'Grid de avaliações',
+    name: 'review-carousel',
+    widget: 'object',
+    icon: 'https://api.iconify.design/bi:grid.svg',
+    fields: [
+      {
+        label: 'Avaliações',
+        name: 'reviews',
+        widget: 'list',
+        fields: [
+          {
+            label: 'Imagem',
+            name: 'img',
+            required: false,
+            widget: 'image',
+            media_library: {
+              config: {
+                max_file_size: Math.max(window.CMS_MAX_FILE_SIZE || 0, 1000000)
+              }
+            }
+          },
+          {
+            label: 'Nome',
+            required: false,
+            name: 'nome',
+            widget: 'string'
+          },
+          {
+            label: 'Cidade',
+            required: false,
+            name: 'cidade',
+            widget: 'string'
+          },
+          {
+            label: 'Texto da avaliação',
+            required: false,
+            name: 'texto',
+            widget: 'text'
+          }
+        ]
+      },
+      {
+        label: 'Título da seção',
+        required: false,
+        name: 'title',
+        widget: 'string'
+      },
+      {
+        label: 'Carousel autoplay',
+        required: false,
+        name: 'autoplay',
+        hint: 'Troca automática das avaliações em milisegundos, defina 0 para desabilitar autoplay',
+        min: 0,
+        step: 1000,
+        default: 9000,
+        widget: 'number'
+      }
+    ]
+  },
+  {
     label: 'Breadcrumbs',
     name: 'breadcrumbs',
     widget: 'object',

--- a/@ecomplus/storefront-template/template/pages/@/sections/review-carousel.ejs
+++ b/@ecomplus/storefront-template/template/pages/@/sections/review-carousel.ejs
@@ -1,0 +1,71 @@
+<%
+const { reviews, title, autoplay } = opt
+
+if (reviews && reviews.length) {
+  %>
+
+  <section class="brands-carousel container reviews">
+    <% if (title) { %>
+      <h4 class="products-carousel__title"><%= title %></h4>
+    <% } %>
+
+    <div
+      class="glide"
+      data-autoplay="<%= autoplay %>"
+      data-per-view="4"
+      data-per-view-md="4"
+      data-per-view-sm="3"
+      data-per-view-xs="1"
+    >
+      <div class="glide__track" data-glide-el="track">
+        <ul class="glide__slides brands-carousel__list">
+          <% reviews.forEach(({ nome, cidade, img, texto }) => { %>
+            <li class="glide__slide brands-carousel__item">
+              <div class="depoimento-box">
+                <div class="title-client-avk">
+                  <% if (img) { %>
+                    <img src="<%= img %>" alt="<%= nome %>" loading="lazy" width="50" height="50">
+                  <% } %>
+                  <% if (nome) { %>
+                    <p><%= nome %></p>
+                  <% } %>
+                  <% if (cidade) { %>
+                    <small><%= cidade %></small>
+                  <% } %>
+                </div>
+                <% if (texto) { %>
+                  <h5><%= texto %></h5>
+                <% } %>
+              </div>
+            </li>
+          <% }) %>
+        </ul>
+
+        <% if (reviews.length > 3) { %>
+          <div
+            class="glide__arrows glide__arrows--outer"
+            data-glide-el="controls"
+          >
+            <button
+              class="btn glide__arrow glide__arrow--left"
+              data-glide-dir="<"
+              aria-label="<%= _.dictionary('previous') %>"
+            >
+              <i class="i-arrow-left"></i>
+            </button>
+            <button
+              class="btn glide__arrow glide__arrow--right"
+              data-glide-dir=">"
+              aria-label="<%= _.dictionary('next') %>"
+            >
+              <i class="i-arrow-right"></i>
+            </button>
+          </div>
+        <% } %>
+      </div>
+    </div>
+  </section>
+
+  <%
+}
+%>

--- a/@ecomplus/storefront-template/template/scss/_main.scss
+++ b/@ecomplus/storefront-template/template/scss/_main.scss
@@ -28,6 +28,7 @@ body {
 @import "components/product";
 @import "components/products-carousel";
 @import "components/retail-grid";
+@import "components/review-carousel";
 @import "components/rounded-icon";
 @import "components/shelfs-nav";
 @import "components/stamps";

--- a/@ecomplus/storefront-template/template/scss/components/_review-carousel.scss
+++ b/@ecomplus/storefront-template/template/scss/components/_review-carousel.scss
@@ -1,0 +1,57 @@
+.reviews {
+  height: unset;
+
+  .products-carousel__title::before {
+    height: 0 !important;
+  }
+
+  .depoimento-box {
+    margin: 0 auto;
+    min-height: 300px;
+    padding: 20px;
+    text-align: center;
+    background: var(--light);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    box-shadow: 0 5px 9px -5px rgba(0, 0, 0, .2);
+  }
+
+  .title-client-avk {
+    text-align: center;
+
+    img {
+      max-height: 70px;
+      margin: 0 auto;
+      border: 1px solid var(--secondary);
+      border-radius: 200px;
+    }
+
+    p {
+      width: 100%;
+      margin-top: .5rem;
+      margin-bottom: .25rem;
+      font-size: var(--font-size-lg);
+      font-weight: 700;
+    }
+
+    small {
+      color: var(--secondary);
+    }
+  }
+
+  @media (min-width: 1200px) {
+    .depoimento-box {
+      text-align: left;
+    }
+
+    .title-client-avk {
+      position: relative;
+      text-align: left;
+
+      img {
+        display: block;
+        margin-bottom: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adiciona a seção "Grid de avaliações" (`review-carousel`) como tipo nativo do CMS em `@ecomplus/storefront-template`, disponível em todos os construtores de página que reaproveitam `sections.js` (home, páginas extras, blog, marcas, categorias, coleções, produtos, busca).

Baseado na personalização feita originalmente na loja jackb2b (commit 283f480), mas com cores no card vindas dos design tokens do tema (`var(--secondary)`, `var(--border-color)`) em vez de hex fixo da marca, e sem o sort morto que comparava um campo (`name`) que os itens não têm (`nome`, `cidade`, `img`, `texto`).

## Verificação
- `npx standard` no `sections.js` alterado: limpo
- Execução real de `getSections()` com `window` mockado: 15 tipos gerados, sem `name` duplicado na lista
- Render do `review-carousel.ejs` via lib `ejs`, 5 cenários (dados completos, exatamente 3 itens, `opt` sem `reviews`, `reviews: []`, texto com HTML/aspas): todos ok, escaping correto
- Compilação isolada do `_review-carousel.scss` e compilação completa do `_main.scss` (com as dependências reais do npm, `@ecomplus/storefront-components` e `@glidejs/glide`): sem erros, sem colisão de classe

Não testado: preview visual no navegador e UI real do admin CMS (`npm run serve` do monorepo pede Node 14; ambiente de teste estava em Node 22).