### PR TITLE
fix(renovate): pin storefront-template to the beta channel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,12 @@
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPackageNames": [
+        "@ecomplus/storefront-template"
+      ],
+      "allowedVersions": "/-beta\\./"
     }
   ]
 }


### PR DESCRIPTION
## Contexto

O `@ecomplus/storefront-template@2.0.0-beta.299` foi tagueado em 24/07 e publicado no GitHub Packages, mas o workflow `Publish` (que espelha GH Packages → npm) vinha falhando desde junho com `403 ... requires two-factor authentication or granular access token with bypass 2fa`. O secret `NPM_TOKEN` já foi rotacionado e o [run 30130972741](https://github.com/ecomplus/storefront/actions/runs/30130972741) rodou verde — a `beta.299` está no npm e o `latest` voltou ao lugar.

## O que este PR resolve

Enquanto a versão existia em tag mas não no registry público, o range `^2.0.0-beta.299` passou a resolver para `2.0.0-next.3` — uma versão de **abril/2020**, já deprecada no npm:

```
^2.0.0-beta.298  ->  2.0.0-beta.298   (ok)
^2.0.0-beta.299  ->  2.0.0-next.3     (!!)
```

O motivo é semver puro: identificadores de pre-release são comparados alfanumericamente, então `next` > `beta`. Normalmente o npm esconde isso porque prefere a versão do dist-tag `latest` quando ela satisfaz o range — mas quando o `latest` não satisfaz, ele cai para a maior versão existente. Foi assim que o #1294 chegou a propor `^2.0.0-beta.299` → `^2.0.0-next.3`.

A publicação da `beta.299` já fechou o buraco atual. Este PR é o cinto de segurança: qualquer nova janela entre "tagueado" e "publicado no npm" reabriria exatamente o mesmo cenário.

## Nota

O `renovate-config-validator` aprova a config (`Config validated successfully`), mas emite um `WARN: Config migration necessary` pré-existente — os `excludePackagePatterns` e o `config:base` estão deprecados em favor de `matchPackageNames` com negação `!` e `config:recommended`. O Renovate migra em runtime, então não quebra nada; fica a nota para uma limpeza à parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)